### PR TITLE
(#100) Fix signup error messages showing before input and add email duplicate validation

### DIFF
--- a/Frontend/src/pages/Register.tsx
+++ b/Frontend/src/pages/Register.tsx
@@ -23,6 +23,7 @@ const Register: React.FC = () => {
   const [passwordTouched, setPasswordTouched] = useState<boolean>(false);
   const [confirmPasswordTouched, setConfirmPasswordTouched] = useState<boolean>(false);
   const [showErrors, setShowErrors] = useState<boolean>(false);
+  const [duplicateEmailError, setDuplicateEmailError] = useState<string | null>(null);
   const [accountType, setAccountType] = useState<string>(""); // "" = not selected
   const timerRef = React.useRef<number | null>(null);
 
@@ -60,7 +61,7 @@ const Register: React.FC = () => {
   // submit
   const signUp = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-  setShowErrors(true);
+    setShowErrors(true);
   if (!isFormValid || submitting || !accountType) return;
     setSubmitting(true);
     try {
@@ -89,7 +90,11 @@ const Register: React.FC = () => {
         e.response?.statusText ||
         e.message ||
         "Registration failed.";
-      message.error(msg);
+      if (e.response?.status === 409) {
+        setDuplicateEmailError("Email already in use.");
+        setEmailTouched(true);
+      }
+      messageApi.error(msg);
       console.error(e);
     } finally {
       setSubmitting(false);
@@ -181,16 +186,23 @@ const Register: React.FC = () => {
                         value={email}
                         onChange={(e) => {
                           if (!emailTouched) setEmailTouched(true);
+                          if (duplicateEmailError) setDuplicateEmailError(null);
                           setEmail(e.target.value);
                         }}
                         className={`mt-2 w-full rounded-lg border px-4 py-3 text-slate-800 outline-none focus:ring-2 bg-slate-50 ${
-                          (emailTouched || showErrors) && !isEmailValid
+                          ((emailTouched || showErrors) && !isEmailValid) ||
+                          duplicateEmailError
                             ? "border-red-500 focus:border-red-500 focus:ring-red-300"
                             : "border-slate-300 focus:border-blue-400 focus:ring-blue-400"
                         }`}
                         placeholder="Enter your email"
                       />
-                      {(emailTouched || showErrors) && !isEmailValid && (
+                      {duplicateEmailError && (
+                        <p className="mt-1 text-sm text-red-500">
+                          {duplicateEmailError}
+                        </p>
+                      )}
+                      {(emailTouched || showErrors) && !isEmailValid && !duplicateEmailError && (
                         <p className="mt-1 text-sm text-red-500">
                           Please enter a valid email address.
                         </p>
@@ -312,16 +324,23 @@ const Register: React.FC = () => {
                         value={email}
                         onChange={(e) => {
                           if (!emailTouched) setEmailTouched(true);
+                          if (duplicateEmailError) setDuplicateEmailError(null);
                           setEmail(e.target.value);
                         }}
                         className={`mt-2 w-full rounded-lg border px-4 py-3 text-slate-800 outline-none focus:ring-2 bg-slate-50 ${
-                          (emailTouched || showErrors) && !isEmailValid
+                          ((emailTouched || showErrors) && !isEmailValid) ||
+                          duplicateEmailError
                             ? "border-red-500 focus:border-red-500 focus:ring-red-300"
                             : "border-slate-300 focus:border-blue-400 focus:ring-blue-400"
                         }`}
                         placeholder="Enter your email"
                       />
-                      {(emailTouched || showErrors) && !isEmailValid && (
+                      {duplicateEmailError && (
+                        <p className="mt-1 text-sm text-red-500">
+                          {duplicateEmailError}
+                        </p>
+                      )}
+                      {(emailTouched || showErrors) && !isEmailValid && !duplicateEmailError && (
                         <p className="mt-1 text-sm text-red-500">
                           Please enter a valid email address.
                         </p>


### PR DESCRIPTION
### Summary
The signup form currently shows all error messages before the user types anything. This fix updates the validation logic so errors only appear after user interaction or submission. Also, email duplication now triggers a red border and an inline “Email already in use.” message

### Testing Instructions 
Go to the Sign up form, and you should only see the error messages when you start typing. Verify that trying to register with an existing email shows the inline “Email already in use.” message and red border.